### PR TITLE
AUTHORS and README.rst not included in source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include LICENSE
+include AUTHORS
+include README.rst


### PR DESCRIPTION
I'd like to package django-djson-field for Debian and I need those two files in the source tarball to ease the packaging.
