### PR TITLE
DecoderError on basestring

### DIFF
--- a/json_field/fields.py
+++ b/json_field/fields.py
@@ -88,7 +88,11 @@ class JSONField(models.TextField):
         if not value:
             return None
         if isinstance(value, basestring):
-            value = json.loads(value, **self.decoder_kwargs)
+            # Catch this exception on eg. foo.json = 'a'
+            try:
+                value = json.loads(value, **self.decoder_kwargs)
+            except json.JSONDecodeError, e:
+                pass
         return value
 
     def get_db_prep_value(self, value, *args, **kwargs):


### PR DESCRIPTION
Hi!

Noticed my tests started failing and I found (with the help of _bisect_)
that "77da4d283236fd949906c8fb1367df03500c5baa is the first bad commit"

The behavior turned out that I couldn't assign like 'a', to a json field anymore;

```
/home/mjt/src/git_checkouts/django-json-field/json_field/fields.pyc in to_python(self, value)
     89             return None
     90         if isinstance(value, basestring):
---> 91             value = json.loads(value, **self.decoder_kwargs)
     92         return value
     93 
[...]
JSONDecodeError: No JSON object could be decoded: line 1 column 0 (char 0)
```

Sure, JSON is identified as a basestring but this is not necessarily what we mean by it ;)

Not sure if this is a problem or not, as we'd usually assign 'a' to it, but if we assign '"a"'
we do **not** end up with 'a' as the value. Instead it gets parsed into _a_, apparently ends
up in _JSONDecoder.decode_ -> _isinstance(obj, basestring)_ and eventually _date_parser.parse(obj)_
which interprets it as a valid date.

Assigning 'ab' and '"ab"' work the same.

Assigning '1' makes it an integer but '"1"' a _Decimal_ for the above reasons.

If these findings should be considered problems they should probably be fixed separately.

This pull request is about a real-world problem anyway with assigning strings :)
