### PR TITLE
Do not call gettext in form class definition

### DIFF
--- a/json_field/fields.py
+++ b/json_field/fields.py
@@ -59,11 +59,11 @@ class JSONField(models.TextField):
 
     description = 'JSON object'
 
-    default_error_messages = {
-        'invalid': _(u'Enter a valid JSON object')
-    }
-
     def __init__(self, *args, **kwargs):
+        default_error_messages = {
+            'invalid': _(u'Enter a valid JSON object')
+        }
+
         self._db_type = kwargs.pop('db_type', None)
         encoder = kwargs.pop('encoder', DjangoJSONEncoder)
         decoder = kwargs.pop('decoder', JSONDecoder)
@@ -76,7 +76,7 @@ class JSONField(models.TextField):
         self.encoder_kwargs = encoder_kwargs
         self.decoder_kwargs = decoder_kwargs
         kwargs['default'] = kwargs.get('default', 'null')
-        kwargs['help_text'] = kwargs.get('help_text', self.default_error_messages['invalid'])
+        kwargs['help_text'] = kwargs.get('help_text', default_error_messages['invalid'])
         super(JSONField, self).__init__(*args, **kwargs)
 
     def db_type(self, connection):


### PR DESCRIPTION
This needs to be so, or eg. _manage.py migrate_ will start loading
models too early and complain about json_field not having JSONField
or anything else.

Note that moving json_field to be the first in INSTALLED_APPS
does not help.

At least that's what I found ;)
