### PR TITLE
Fix install with Django 1.5

### DIFF
--- a/json_field/__init__.py
+++ b/json_field/__init__.py
@@ -1,6 +1,7 @@
+from django.core.exceptions import ImproperlyConfigured
 try:
     from json_field.fields import JSONField
-except ImportError:
+except (ImportError, ImproperlyConfigured):
     pass # fails when imported by setup.py, no worries
 
 __version__ = '0.4.2'


### PR DESCRIPTION
In Django 1.5 when you import JSONField in **init** it raises ImproperlyConfigured instead ImportError, this pull request fix it.
