### PR TITLE
Add proper South introspection rules, fixing db_type for migrations.

### DIFF
--- a/json_field/fields.py
+++ b/json_field/fields.py
@@ -142,6 +142,15 @@ class JSONField(models.TextField):
 try:
     # add support for South migrations
     from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([], ['^json_field\.fields\.JSONField'])
+    rules = [
+        (
+            (JSONField,),
+            [],
+            {
+                'db_type': ['_db_type', {'default': None}]
+            }
+        )
+    ]
+    add_introspection_rules(rules, ['^json_field\.fields\.JSONField'])
 except ImportError:
     pass


### PR DESCRIPTION
Since South didn't know that it had to include the `db_type` argument when initializing the field, the actual `db_type` value that got written to the database was always the same as TextField. In Postgres, this would be `text` even if you passed `json`. (It only worked correctly if you were using `syncdb` instead.)

Now South correctly adds the right arguments when creating migration files:

```
('data', self.gf('json_field.fields.JSONField')(default='null', db_type='json')),
```
