### PR TITLE
make json_field work with django 1.7+ properly

### DIFF
--- a/json_field/forms.py
+++ b/json_field/forms.py
@@ -2,7 +2,14 @@ try:
     import json
 except ImportError:  # python < 2.6
     from django.utils import simplejson as json
-from django.forms import fields, util
+
+from django.forms import fields    
+
+import warnings
+try:
+    from django.forms import util
+except (Warning, ImportError):
+    from django.forms import utils as util
 
 import datetime
 from decimal import Decimal


### PR DESCRIPTION
django.form.util is renamed to django.form.utils and will be removed starting v1.9
http://django.readthedocs.org/en/latest/releases/1.7.html#util-modules-renamed-to-utils
