### PR TITLE
Fix django 1.8 deprecation warning

### DIFF
--- a/json_field/forms.py
+++ b/json_field/forms.py
@@ -2,7 +2,13 @@ try:
     import json
 except ImportError:  # python < 2.6
     from django.utils import simplejson as json
-from django.forms import fields, util
+
+try:
+    from django.forms.utils import ValidationError
+except ImportError:  # old django versions
+    from django.forms.util import ValidationError
+
+from django.forms import fields
 
 import datetime
 from decimal import Decimal
@@ -45,9 +51,9 @@ class JSONFormField(fields.Field):
             try:
                 value = json.dumps(eval(value, json_globals, json_locals), **self.encoder_kwargs)
             except Exception as e: # eval can throw many different errors
-                raise util.ValidationError(str(e))
+                raise ValidationError(str(e))
 
         try:
             return json.loads(value, **self.decoder_kwargs)
         except ValueError as e:
-            raise util.ValidationError(str(e))
+            raise ValidationError(str(e))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except IOError:
 
 setup(
     name = 'django-json-field',
-    version = '0.5.7',
+    version = '0.5.8',
     description = description,
     author = 'Derek Schaefer',
     author_email = 'derek.schaefer@gmail.com',

--- a/test_project/app/forms.py
+++ b/test_project/app/forms.py
@@ -8,6 +8,7 @@ from json_field.forms import JSONFormField
 class ModelForm(forms.ModelForm):
     class Meta:
         model = Test
+        fields = '__all__'
 
 class TestForm(forms.Form):
     json = JSONFormField()


### PR DESCRIPTION
This PR fix Django 1.8 deprecation warning without breaking backwards compatibility and also fix the test suite that was breaking at Django 1.8 